### PR TITLE
Refactor model fitting interfaces

### DIFF
--- a/src/tree_grid/family/grown.rs
+++ b/src/tree_grid/family/grown.rs
@@ -15,6 +15,116 @@ use crate::{
 };
 
 use super::TreeGridFamily;
+
+pub fn fit(
+    x: ArrayView2<f64>,
+    y: ArrayView1<f64>,
+    hyperparameters: &TreeGridFamilyGrownParams,
+) -> (FitResult, TreeGridFamily<GrownVariant>) {
+    let dims = x.shape()[1];
+    let intercept_grid = TreeGridFitter::new(x.view(), y.view());
+    let mut tg_fitters = HashMap::new();
+    let y_hat = intercept_grid.y_hat.clone();
+    let residuals = y.to_owned() - &y_hat;
+    tg_fitters.insert(BTreeSet::new(), vec![intercept_grid]);
+
+    let mut fitter = TreeGridFamilyGrownFitter {
+        dims,
+        x: x.view(),
+        y: y.view(),
+        tg_fitters,
+        y_hat,
+        residuals,
+    };
+
+    let TreeGridFamilyGrownParams {
+        n_iter,
+        m_try,
+        split_try,
+    } = *hyperparameters;
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..n_iter {
+        let potential_splits = fitter.potential_splits();
+        let n_potential_splits = potential_splits.len();
+        let n_splits_to_try = (n_potential_splits as f64 * m_try).ceil() as usize;
+
+        let mut candidates = Vec::new();
+        let split_indices: Vec<usize> = (0..n_potential_splits).collect();
+        let selected_splits: Vec<usize> = split_indices
+            .choose_multiple(&mut rng, n_splits_to_try)
+            .copied()
+            .collect();
+
+        for &p_idx in &selected_splits {
+            let (s, dim, sample_tg_idx) = potential_splits[p_idx].clone();
+
+            let mut best_split = None;
+            let mut best_err_diff = f64::NEG_INFINITY;
+
+            for _ in 0..split_try {
+                let split_idx = rng.gen_range(0..x.nrows());
+                let split_val = x[[split_idx, dim]];
+
+                if let Some(tg_fitters) = fitter.tg_fitters.get(&s) {
+                    if let Some(sample_tg) = tg_fitters.get(sample_tg_idx) {
+                        let slice_candidate = find_slice_candidate(
+                            &sample_tg.splits,
+                            &sample_tg.intervals,
+                            dim,
+                            split_val,
+                        );
+                        let (err_new, err_old, refine_candidate) = find_refine_candidate(
+                            slice_candidate,
+                            sample_tg.x,
+                            &sample_tg.leaf_points,
+                            &sample_tg.grid_values,
+                            &sample_tg.intervals,
+                            fitter.residuals.view(),
+                            fitter.y_hat.view(),
+                        );
+                        let err_diff = err_old - err_new;
+
+                        if err_diff > best_err_diff {
+                            best_err_diff = err_diff;
+                            best_split = Some((s.clone(), sample_tg_idx, refine_candidate));
+                        }
+                    }
+                }
+            }
+
+            if let Some(split) = best_split {
+                candidates.push((best_err_diff, split));
+            }
+        }
+
+        if let Some((_, (s, sample_tg_idx, refine_candidate))) =
+            candidates.into_iter().max_by(|a, b| {
+                let a_diff = a.0;
+                let b_diff = b.0;
+                a_diff.partial_cmp(&b_diff).unwrap()
+            })
+        {
+            fitter.update_estimator(s, sample_tg_idx, refine_candidate);
+        }
+    }
+
+    let fit_result = FitResult {
+        err: fitter.loss(),
+        residuals: fitter.residuals,
+        y_hat: fitter.y_hat,
+    };
+
+    let fitted_tree_grids = fitter
+        .tg_fitters
+        .into_values()
+        .flatten()
+        .map_into()
+        .collect();
+
+    (fit_result, TreeGridFamily(fitted_tree_grids, PhantomData))
+}
+
 #[derive(Debug)]
 pub struct GrownVariant;
 
@@ -129,113 +239,4 @@ impl TreeGridFamilyGrownFitter<'_> {
 
         self.update_residuals();
     }
-}
-
-pub fn fit(
-    x: ArrayView2<f64>,
-    y: ArrayView1<f64>,
-    hyperparameters: &TreeGridFamilyGrownParams,
-) -> (FitResult, TreeGridFamily<GrownVariant>) {
-    let dims = x.shape()[1];
-    let intercept_grid = TreeGridFitter::new(x.view(), y.view());
-    let mut tg_fitters = HashMap::new();
-    let y_hat = intercept_grid.y_hat.clone();
-    let residuals = y.to_owned() - &y_hat;
-    tg_fitters.insert(BTreeSet::new(), vec![intercept_grid]);
-
-    let mut fitter = TreeGridFamilyGrownFitter {
-        dims,
-        x: x.view(),
-        y: y.view(),
-        tg_fitters,
-        y_hat,
-        residuals,
-    };
-
-    let TreeGridFamilyGrownParams {
-        n_iter,
-        m_try,
-        split_try,
-    } = *hyperparameters;
-    let mut rng = rand::thread_rng();
-
-    for _ in 0..n_iter {
-        let potential_splits = fitter.potential_splits();
-        let n_potential_splits = potential_splits.len();
-        let n_splits_to_try = (n_potential_splits as f64 * m_try).ceil() as usize;
-
-        let mut candidates = Vec::new();
-        let split_indices: Vec<usize> = (0..n_potential_splits).collect();
-        let selected_splits: Vec<usize> = split_indices
-            .choose_multiple(&mut rng, n_splits_to_try)
-            .copied()
-            .collect();
-
-        for &p_idx in &selected_splits {
-            let (s, dim, sample_tg_idx) = potential_splits[p_idx].clone();
-
-            let mut best_split = None;
-            let mut best_err_diff = f64::NEG_INFINITY;
-
-            for _ in 0..split_try {
-                let split_idx = rng.gen_range(0..x.nrows());
-                let split_val = x[[split_idx, dim]];
-
-                if let Some(tg_fitters) = fitter.tg_fitters.get(&s) {
-                    if let Some(sample_tg) = tg_fitters.get(sample_tg_idx) {
-                        let slice_candidate = find_slice_candidate(
-                            &sample_tg.splits,
-                            &sample_tg.intervals,
-                            dim,
-                            split_val,
-                        );
-                        let (err_new, err_old, refine_candidate) = find_refine_candidate(
-                            slice_candidate,
-                            sample_tg.x,
-                            &sample_tg.leaf_points,
-                            &sample_tg.grid_values,
-                            &sample_tg.intervals,
-                            fitter.residuals.view(),
-                            fitter.y_hat.view(),
-                        );
-                        let err_diff = err_old - err_new;
-
-                        if err_diff > best_err_diff {
-                            best_err_diff = err_diff;
-                            best_split = Some((s.clone(), sample_tg_idx, refine_candidate));
-                        }
-                    }
-                }
-            }
-
-            if let Some(split) = best_split {
-                candidates.push((best_err_diff, split));
-            }
-        }
-
-        if let Some((_, (s, sample_tg_idx, refine_candidate))) =
-            candidates.into_iter().max_by(|a, b| {
-                let a_diff = a.0;
-                let b_diff = b.0;
-                a_diff.partial_cmp(&b_diff).unwrap()
-            })
-        {
-            fitter.update_estimator(s, sample_tg_idx, refine_candidate);
-        }
-    }
-
-    let fit_result = FitResult {
-        err: fitter.loss(),
-        residuals: fitter.residuals,
-        y_hat: fitter.y_hat,
-    };
-
-    let fitted_tree_grids = fitter
-        .tg_fitters
-        .into_values()
-        .flatten()
-        .map_into()
-        .collect();
-
-    (fit_result, TreeGridFamily(fitted_tree_grids, PhantomData))
 }

--- a/src/tree_grid/grid/fitter.rs
+++ b/src/tree_grid/grid/fitter.rs
@@ -8,6 +8,14 @@ use crate::{FitResult, ModelFitter};
 
 use super::FittedTreeGrid;
 
+pub fn fit(
+    x: ArrayView2<f64>,
+    y: ArrayView1<f64>,
+    hyperparameters: &TreeGridParams,
+) -> (FitResult, FittedTreeGrid) {
+    TreeGridFitter::new(x.view(), y.view()).fit(hyperparameters)
+}
+
 #[derive(Debug)]
 pub struct TreeGridFitter<'a> {
     pub splits: Vec<Vec<f64>>,


### PR DESCRIPTION
This pull request refactors the `TreeGridFamily` module by simplifying the code structure and removing unnecessary traits and structs. The most important changes include the removal of the `FitAndPredictStrategy` trait, the restructuring of the `TreeGridFamily` struct, and the addition of a `fit` function in the `grid::fitter` module.

Code structure simplification:

* Removed the `FitAndPredictStrategy` trait and the `TreeGridFamilyFitter` struct from `src/tree_grid/family.rs`.
* Restructured the `TreeGridFamily` struct to use a `PhantomData` marker instead of a generic parameter.
* Moved the `BaggedVariant` and `TreeGridFamilyBaggedParams` structs to the end of the `fit` function in `src/tree_grid/family/bagged.rs`.
* Moved the `GrownVariant` struct and the `fit` function in `src/tree_grid/family/grown.rs` to improve readability.

New utility function:

* Added a `fit` function in `src/tree_grid/grid/fitter.rs` to encapsulate the fitting logic for `TreeGridFitter`.