### PR TITLE
Improve ergonomics of Python interface

### DIFF
--- a/mpf-py/pyproject.toml
+++ b/mpf-py/pyproject.toml
@@ -2,12 +2,6 @@
 requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
-[project]
-name = "mpf_rust"
-requires-python = ">=3.7"
-version = "3.13"
-classifiers = [
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-]
+[tool.maturin]
+python-source = "python"
+module-name = "mpf_py._mpf_py"

--- a/mpf-py/python/mpf_py/__init__.py
+++ b/mpf-py/python/mpf_py/__init__.py
@@ -1,0 +1,6 @@
+from mpf_py.mpf import TreeGrid
+from mpf_py.mpf import MPF
+from mpf_py._mpf_py import FitResult
+
+
+__all__ = ["TreeGrid", "MPF", "FitResult"]

--- a/mpf-py/python/mpf_py/main.py
+++ b/mpf-py/python/mpf_py/main.py
@@ -14,7 +14,7 @@ y = sin(x1) * cos(x2) + 2 * x1 - 2 * x2 + rnorm(n, sd=0.3)
 dat = data.frame(y, x1, x2)
 write.csv(dat, "dat.csv", row.names = FALSE)
 """
-df = pd.read_csv("../../dat.csv")
+df = pd.read_csv("../dat.csv")
 x = df.iloc[:, 1:].values
 y = df.iloc[:, 0].values
 

--- a/mpf-py/python/mpf_py/mpf.py
+++ b/mpf-py/python/mpf_py/mpf.py
@@ -1,0 +1,146 @@
+
+import numpy as np
+from mpf_py._mpf_py import TreeGrid as _TreeGrid
+from mpf_py._mpf_py import MPFBagged as _MPFBagged
+from mpf_py._mpf_py import MPFGrown as _MPFGrown
+
+from mpf_py._mpf_py import FitResult
+from mpf_py.wrapper import PythonWrapperClassBase
+
+
+
+class TreeGrid(PythonWrapperClassBase, RustClass=_TreeGrid):
+    
+    def __init__(self, tg):
+        super().__init__()
+        self._rust_instance = tg
+
+    @classmethod
+    def fit(
+        cls, 
+        x: np.typing.NDArray[np.float64], 
+        y: np.typing.NDArray[np.float64],
+        n_iter: int,
+        split_try: int, 
+        colsample_bytree: float
+    ) -> tuple["TreeGrid", "FitResult"]:
+        tg, fr = _TreeGrid.fit(x, y, n_iter, split_try, colsample_bytree)
+        return cls(tg), fr
+
+
+    def predict(self, x: np.typing.NDArray[np.float64]) -> np.typing.NDArray[np.float64]:
+        return self._rust_instance.predict(x)
+    
+    def get_component(self, axis: int):
+        intervals = self.intervals[axis]
+        values = self.grid_values[axis]
+
+        return [*zip(intervals, values)]
+
+    def plot(self, axis: int):
+
+        component = self.get_component(axis)
+        try: 
+            import matplotlib.pyplot as plt
+        except ImportError:
+            raise ImportError(
+                "Matplotlib is required to use the 'plot' function. "
+                "Please install it using: pip install matplotlib"
+            )
+    
+        plt.figure(figsize=(10, 6))
+
+        # Iterate through the intervals and corresponding values
+        for (x_start, x_end), y in component:
+            # Handle infinity
+            if x_start == -np.inf:
+                x_start = x_end - 2 
+            if x_end == np.inf:
+                x_end = x_start + 2
+
+            plt.hlines(y, x_start, x_end, color='b', lw=2)  # Draw horizontal lines
+
+        # Set labels and title
+        plt.xlabel('X-axis')
+        plt.ylabel('Values')
+        plt.title(f'Component values on Axis: {axis + 1}')
+        plt.grid(True)
+        plt.show()
+
+    
+
+class MPF:
+
+    class Bagged(PythonWrapperClassBase, RustClass=_MPFBagged):
+        def __init__(self, mpf_bagged):
+            super().__init__()
+            self._rust_instance = mpf_bagged
+
+        @classmethod
+        def fit(
+            cls, 
+            x: np.typing.NDArray[np.float64], 
+            y: np.typing.NDArray[np.float64],
+            epochs: int,
+            B: int,
+            n_iter: int,
+            split_try: int, 
+            colsample_bytree: float
+        ) -> tuple["MPF.Bagged", "FitResult"]:
+            mpf_bagged, fr = _MPFBagged.fit(x, y, epochs, B, n_iter, split_try, colsample_bytree)
+            instance = cls(mpf_bagged)
+            instance._tree_grid_families = [[TreeGrid(tg) for tg in tf] for tf in instance.tree_grid_families]
+            return instance, fr
+
+        def predict(self, x: np.typing.NDArray[np.float64]) -> np.typing.NDArray[np.float64]:
+            return self._rust_instance.predict(x)
+
+
+    class Grown(PythonWrapperClassBase, RustClass=_MPFGrown):
+        def __init__(self, mpf_grown):
+            super().__init__()
+            self._rust_instance = mpf_grown
+        
+        @classmethod
+        def fit(
+            cls, 
+            x: np.typing.NDArray[np.float64], 
+            y: np.typing.NDArray[np.float64],
+            n_iter: int,
+            split_try: int, 
+            colsample_bytree: float
+        ) -> tuple["MPF.Grown", "FitResult"]:
+            mpf_grown, fr = _MPFGrown.fit(x, y, n_iter, split_try, colsample_bytree)
+            instance = cls(mpf_grown)
+            instance._tree_grid_families = [[TreeGrid(tg) for tg in tf] for tf in instance.tree_grid_families]
+            return instance, fr
+
+
+    def __init__(self, mpf):
+        self._mpf = mpf
+        self.variant = self._mpf.__class__.__name__
+
+        for attr in dir(self._mpf):
+            if attr.startswith("__"):
+                continue
+            if not callable(getattr(self._mpf, attr)):
+                setattr(self, attr, getattr(self._mpf, attr))
+
+    @classmethod
+    def fit_bagged(
+        cls, 
+        *args, **kwargs
+    ) -> tuple["MPF.Bagged", "FitResult"]:
+        mpf_bagged, fr = cls.Bagged.fit(*args, **kwargs)
+        return cls(cls.Bagged(mpf_bagged)), fr
+    
+    @classmethod
+    def fit_grown(
+        cls, 
+        *args, **kwargs
+    ) -> tuple["MPF.Grown", "FitResult"]:
+        mpf_grown, fr = cls.Grown.fit(*args, **kwargs)
+        return cls(cls.Grown(mpf_grown)), fr
+    
+    def predict(self, x: np.typing.NDArray[np.float64]) -> np.typing.NDArray[np.float64]:
+        return self._mpf.predict(x)

--- a/mpf-py/python/mpf_py/wrapper.py
+++ b/mpf-py/python/mpf_py/wrapper.py
@@ -1,0 +1,40 @@
+from abc import ABC
+
+
+class PythonWrapperClassBase(ABC):
+    __slots__ = ["_rust_instance"]
+
+    def _get_property_value(self, property_name):
+        """
+        Helper method to get or snapshot a property value on-demand.
+        """
+        private_attr_name = "_" + property_name
+        if not hasattr(self, private_attr_name):
+            rust_property_value = getattr(self._rust_instance, property_name)
+            setattr(self, private_attr_name, rust_property_value)
+        return getattr(self, private_attr_name) # Return snapshotted value
+
+
+    @classmethod
+    def __init_subclass__(cls, RustClass=None, **kwargs):
+        """
+        Dynamically creates properties and passthrough methods on subclasses.
+
+        Args:
+            RustClass: The PyO3 Rust class to wrap. Must be provided when subclassing.
+        """
+        super().__init_subclass__(**kwargs)
+
+        if RustClass is None:
+            raise TypeError("RustClass must be specified as a keyword argument when subclassing PythonWrapperClassBase.")
+
+        for attr_name in dir(RustClass):
+            if attr_name.startswith("__"):
+                continue
+            attr = getattr(RustClass, attr_name)
+            if not callable(attr):
+                # Create dynamic Python property for Rust properties
+                property_wrapper = property(
+                    lambda instance_self, name=attr_name: instance_self._get_property_value(name)
+                ) # Create Python property
+                setattr(cls, attr_name, property_wrapper) # Set property on Python wrapper class


### PR DESCRIPTION
This pull request includes significant changes to the `mpf-py` project, focusing on restructuring the project files, updating dependencies, and enhancing the Python-Rust interface. The most important changes include updating the `pyproject.toml` configuration, adding new imports and exports in the `__init__.py` file, renaming and modifying paths in the `main.py` file, implementing new classes and methods in the `mpf.py` file, and refining the Rust-Python bindings in the `lib.rs` file.

### Project Configuration and Structure:
* Updated `pyproject.toml` to configure the `maturin` tool and set the module name to `mpf_py._mpf_py`.

### Python Module Enhancements:
* Added new imports and exports in `mpf_py/__init__.py` to include `TreeGrid`, `MPF`, and `FitResult`.
* Renamed `main.py` to `mpf_py/main.py` and updated the CSV file path to ensure correct data loading.

### Class Implementations and Methods:
* Implemented `TreeGrid`, `MPF`, and related classes in `mpf.py`, including methods for fitting models, predicting, and plotting results.
* Introduced the `PythonWrapperClassBase` in `wrapper.py` to dynamically create properties and passthrough methods for Rust classes.

### Rust-Python Bindings:
* Refined the `FitResultPy` struct and conversion methods in `lib.rs` to improve the interoperability between Rust and Python. [[1]](diffhunk://#diff-cc7ec5d19c205133cdbf896a590ebbf7796e0ff72d2cd834e156c40457f524b7L56-R71) [[2]](diffhunk://#diff-cc7ec5d19c205133cdbf896a590ebbf7796e0ff72d2cd834e156c40457f524b7L97-R106) [[3]](diffhunk://#diff-cc7ec5d19c205133cdbf896a590ebbf7796e0ff72d2cd834e156c40457f524b7L143-R152) [[4]](diffhunk://#diff-cc7ec5d19c205133cdbf896a590ebbf7796e0ff72d2cd834e156c40457f524b7L158-R167) [[5]](diffhunk://#diff-cc7ec5d19c205133cdbf896a590ebbf7796e0ff72d2cd834e156c40457f524b7L198-R207) [[6]](diffhunk://#diff-cc7ec5d19c205133cdbf896a590ebbf7796e0ff72d2cd834e156c40457f524b7L252-L272)
* Renamed the Rust module function from `mpf_py` to `_mpf_py` to align with the new module naming convention.